### PR TITLE
Arreglo img del logo en movil

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -201,10 +201,13 @@ footer img{
     footer span{
         text-align: center;
     }
-    .social-media img{
+    /* .social-media img{
         height: auto;
         width: 5vw;
-}   
+    }    */
+    #antharious-logo{
+        display: none;
+    }
 
 }
 

--- a/index.html
+++ b/index.html
@@ -145,7 +145,7 @@
         </div>
     </section>
     <footer class="footer">
-        <img src="./assets/img/antharious_b.png" alt="antharious-logo" loading="lazy">
+        <img src="./assets/img/antharious_b.png" alt="antharious-logo" loading="lazy" id="antharious-logo">
         <div class="antharious-info">
             <!-- https://www.iconfinder.com/social-media-icons -->
             <div class="social-media">


### PR DESCRIPTION
Se quitó la imagen del logo en dispositivos móviles para evitar arreglarla cuando se ponen en horizontal.